### PR TITLE
Streaming replication is pathologically slow

### DIFF
--- a/lib/write-stream.js
+++ b/lib/write-stream.js
@@ -13,7 +13,11 @@ var Stream       = require('stream').Stream
 
   , getOptions   = require('./util').getOptions
 
-  , defaultOptions = { type: 'put' }
+  , defaultOptions = {
+        type                 : 'put'
+      , maxBufferLength      : 1000
+      , maxConcurrentBatches : 4
+    }
 
 function WriteStream (options, db) {
   Stream.call(this)
@@ -22,17 +26,18 @@ function WriteStream (options, db) {
   this._buffer  = []
   this._status  = 'init'
   this._end     = false
+  this._activeBatches = 0
   this.writable = true
   this.readable = false
 
   var self = this
-  var ready = function () {
-    if (!self.writable)
-      return
-    self._status = 'ready'
-    self.emit('ready')
-    self._process()
-  }
+    , ready = function () {
+        if (!self.writable)
+          return
+        self._status = 'ready'
+        self.emit('ready')
+        self._process()
+      }
 
   if (db.isOpen())
     setImmediate(ready)
@@ -43,6 +48,15 @@ function WriteStream (options, db) {
 inherits(WriteStream, Stream)
 
 WriteStream.prototype.write = function (data) {
+/*
+  var b = this.__write(data)
+  if (!b)
+    console.log('PAUSE')
+  return b
+}
+
+WriteStream.prototype.__write = function (data) {
+*/
   if (!this.writable)
     return false
   this._buffer.push(data)
@@ -53,7 +67,8 @@ WriteStream.prototype.write = function (data) {
     this._writeBlock = true
     return false
   }
-  return true
+  return !this._options.maxConcurrentBatches ||
+    this._options.maxConcurrentBatches > this._activeBatches
 }
 
 WriteStream.prototype.end = function (data) {
@@ -87,9 +102,9 @@ WriteStream.prototype.add = function (entry) {
 
 WriteStream.prototype._processDelayed = function () {
   var self = this
-  setImmediate(function () {
+  setTimeout(function () {
     self._process()
-  })
+  }, 10)
 }
 
 WriteStream.prototype._process = function () {
@@ -97,6 +112,7 @@ WriteStream.prototype._process = function () {
     , self = this
 
     , cb = function (err) {
+        self._activeBatches--
         if (!self.writable)
           return
         if (self._status != 'closed')
@@ -105,7 +121,7 @@ WriteStream.prototype._process = function () {
           self.writable = false
           return self.emit('error', err)
         }
-        self._process()
+        self._processDelayed()
       }
 
   if (self._status != 'ready' && self.writable) {
@@ -118,7 +134,8 @@ WriteStream.prototype._process = function () {
     self._status = 'writing'
     buffer       = self._buffer
     self._buffer = []
-
+    self._activeBatches++
+    //console.log('batch:', buffer.length)
     self._db.batch(buffer.map(function (d) {
       return {
           type          : d.type || self._options.type

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
       , "bops"                : "~0.0.6"
     }
   , "devDependencies" : {
-        "leveldown"       : "~0.5.0"
+        "leveldown"       : "~0.6.0"
       , "bustermove"      : "*"
       , "tap"             : "*"
       , "referee"         : "*"


### PR DESCRIPTION
Streaming one level instance into another is much slower than expected. @dominictarr was looking into this with me at Nodeconf using this gist https://gist.github.com/brycebaril/5893248

The gist has two files, one that creates a small 1e6 record leveldb instance (~24MB on disk) and another which will attempt to use `db1.createReadStream().pipe(db2.createWriteStream())` to clone the instance to another level instance.

What we were seeing is that once the initial batch is sent, each buffered batch will typically be only a single record, significantly slowing down the transfer. In our case it was taking ~75 seconds.