### PR TITLE
check notFound on err

### DIFF
--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -213,7 +213,7 @@ LevelUP.prototype.get = function (key_, options, callback) {
 
   this.db.get(key, options, function (err, value) {
     if (err) {
-      if ((/notfound/i).test(err)) {
+      if ((/notfound/i).test(err) || err.notFound) {
         err = new NotFoundError(
             'Key not found in database [' + key_ + ']', err)
       } else {


### PR DESCRIPTION
When do a `db.get`, check for `.notFound` on `err` to determine if a `NotFoundError` should be created.

[Related downstream issue](https://github.com/substack/level-create-batch/issues/2)