### PR TITLE
update logo and copyright

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 LevelUP
 =======
 
-![LevelDB Logo](https://0.gravatar.com/avatar/a498b122aecb7678490a38bb593cc12d)
+<img alt="LevelDB Logo" height="100" src="http://leveldb.org/img/logo.svg">
 
 **Fast & simple storage - a Node.js-style LevelDB wrapper**
 
@@ -730,7 +730,7 @@ A large portion of the Windows support comes from code by [Krzysztof Kowalczyk](
 License &amp; copyright
 -------------------
 
-Copyright (c) 2012-2014 LevelUP contributors (listed above).
+Copyright (c) 2012-2015 LevelUP contributors (listed above).
 
 LevelUP is licensed under the MIT license. All rights not explicitly granted in the MIT license are reserved. See the included LICENSE.md file for more details.
 


### PR DESCRIPTION
The logo in this README worked but I changed it to the one we are using on `leveldb.org`. Also I think it's pretty cool to link to a logo from a site we are hosting. Also makes it easier to replace it later with another svg if we like.