### PR TITLE
Added errors to the available namespace when requiring 'levelup'.

### DIFF
--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -449,6 +449,7 @@ function utilStatic (name) {
 }
 
 module.exports         = LevelUP
+module.exports.errors  = require('./errors');
 // DEPRECATED: prefer accessing LevelDOWN for this: require('leveldown').destroy()
 module.exports.destroy = utilStatic('destroy')
 // DEPRECATED: prefer accessing LevelDOWN for this: require('leveldown').repair()

--- a/test/batch-test.js
+++ b/test/batch-test.js
@@ -3,7 +3,8 @@
  * MIT License <https://github.com/rvagg/node-levelup/blob/master/LICENSE.md>
  */
 
-var errors  = require('../lib/errors.js')
+var levelup = require('../lib/levelup')
+  , errors  = levelup.errors
   , async   = require('async')
   , common  = require('./common')
 

--- a/test/common.js
+++ b/test/common.js
@@ -13,7 +13,10 @@ var referee = require('referee')
   , path    = require('path')
   , delayed = require('delayed').delayed
   , levelup = require('../lib/levelup.js')
+  , errors  = require('../lib/errors')
   , dbidx   = 0
+
+assert(levelup.errors === errors);
 
 referee.add('isInstanceOf', {
     assert: function (actual, expected) {

--- a/test/get-put-del-test.js
+++ b/test/get-put-del-test.js
@@ -3,7 +3,8 @@
  * MIT License <https://github.com/rvagg/node-levelup/blob/master/LICENSE.md>
  */
 
-var errors  = require('../lib/errors.js')
+var levelup = require('../lib/levelup.js')
+  , errors  = levelup.errors
   , async   = require('async')
   , common  = require('./common')
 

--- a/test/init-test.js
+++ b/test/init-test.js
@@ -4,7 +4,7 @@
  */
 
 var levelup = require('../lib/levelup.js')
-  , errors  = require('../lib/errors.js')
+  , errors  = levelup.errors
   , fs      = require('fs')
   , common  = require('./common')
 

--- a/test/null-and-undefined-test.js
+++ b/test/null-and-undefined-test.js
@@ -4,7 +4,7 @@
  */
 
 var levelup = require('../lib/levelup.js')
-  , errors  = require('../lib/errors.js')
+  , errors  = levelup.errors
   , common  = require('./common')
 
   , assert  = require('referee').assert

--- a/test/optional-leveldown-test.js
+++ b/test/optional-leveldown-test.js
@@ -3,10 +3,11 @@
  * MIT License <https://github.com/rvagg/node-levelup/blob/master/LICENSE.md>
  */
 
-var assert  = require('referee').assert
+var levelup = require('../lib/levelup')
+  , assert  = require('referee').assert
   , refute  = require('referee').refute
   , buster  = require('bustermove')
-  , errors  = require('../lib/errors')
+  , errors  = levelup.errors
 
 function clearCache () {
   delete require.cache[require.resolve('..')]


### PR DESCRIPTION
This adds the errors to the available namespace so that it can be used from `levelup`.

```javascript
var levelup = require('levelup');
var db = levelup('./somedata');

db.get('somekey', function(err, value) {
  if (err instanceof levelup.errors.NotFoundError) {
    return db.put('somekey', 'somedata', function (err) {
      if (err) {
        throw err;
      }
    });
  } else if (err) {
    throw err;
  }
});
```