### PR TITLE
remove encoding option

### DIFF
--- a/lib/codec.js
+++ b/lib/codec.js
@@ -12,8 +12,8 @@ function getKeyEncoder (options, op) {
 }
 
 function getValueEncoder (options, op) {
-  var type = (((op && (op.valueEncoding || op.encoding))
-      || options.valueEncoding || options.encoding)) || 'utf8'
+  var type = (((op && op.valueEncoding)
+      || options.valueEncoding)) || 'utf8'
   return encodings[type] || type
 }
 

--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -312,7 +312,7 @@ LevelUP.prototype.batch = function (arr_, options, callback) {
 
     // inherit encoding
     var kEnc = e.keyEncoding || keyEnc
-      , vEnc = e.valueEncoding || e.encoding || valueEnc
+      , vEnc = e.valueEncoding || valueEnc
       , o
 
     // If we're not dealing with plain utf8 strings or plain
@@ -377,8 +377,8 @@ LevelUP.prototype.createReadStream = function (options) {
   var self = this
   options = extend( {keys: true, values: true}, this.options, options)
 
-  options.keyEncoding   = options.keyEncoding   || options.encoding
-  options.valueEncoding = options.valueEncoding || options.encoding
+  options.keyEncoding   = options.keyEncoding
+  options.valueEncoding = options.valueEncoding
 
   if (isDefined(options.start))
     options.start = this._codec.encodeKey(options.start, options)

--- a/lib/util.js
+++ b/lib/util.js
@@ -25,8 +25,6 @@ var extend        = require('xtend')
 
 function getOptions (levelup, options) {
   var s = typeof options == 'string' // just an encoding
-  if (!s && options && options.encoding && !options.valueEncoding)
-    options.valueEncoding = options.encoding
   return extend(
       (levelup && levelup.options) || {}
     , s ? encodingOpts[options] || encodingOpts[defaultOptions.valueEncoding]

--- a/test/binary-test.js
+++ b/test/binary-test.js
@@ -28,11 +28,11 @@ buster.testCase('Binary API', {
       common.checkBinaryTestData(this.testData, done)
     }
 
-  , 'test put() and get() with binary value {encoding:binary}': function (done) {
+  , 'test put() and get() with binary value {valueEncoding:binary}': function (done) {
       this.openTestDatabase(function (db) {
-        db.put('binarydata', this.testData, { encoding: 'binary' }, function (err) {
+        db.put('binarydata', this.testData, { valueEncoding: 'binary' }, function (err) {
           refute(err)
-          db.get('binarydata', { encoding: 'binary' }, function (err, value) {
+          db.get('binarydata', { valueEncoding: 'binary' }, function (err, value) {
             refute(err)
             assert(value)
             common.checkBinaryTestData(value, done)
@@ -41,8 +41,8 @@ buster.testCase('Binary API', {
       }.bind(this))
     }
 
-  , 'test put() and get() with binary value {encoding:binary} on createDatabase()': function (done) {
-      this.openTestDatabase({ createIfMissing: true, errorIfExists: true, encoding: 'binary' }, function (db) {
+  , 'test put() and get() with binary value {valueEncoding:binary} on createDatabase()': function (done) {
+      this.openTestDatabase({ createIfMissing: true, errorIfExists: true, valueEncoding: 'binary' }, function (db) {
         db.put('binarydata', this.testData, function (err) {
           refute(err)
           db.get('binarydata', function (err, value) {
@@ -54,11 +54,11 @@ buster.testCase('Binary API', {
       }.bind(this))
     }
 
-  , 'test put() and get() with binary key {encoding:binary}': function (done) {
+  , 'test put() and get() with binary key {valueEncoding:binary}': function (done) {
       this.openTestDatabase(function (db) {
-        db.put(this.testData, 'binarydata', { encoding: 'binary' }, function (err) {
+        db.put(this.testData, 'binarydata', { valueEncoding: 'binary' }, function (err) {
           refute(err)
-          db.get(this.testData, { encoding: 'binary' }, function (err, value) {
+          db.get(this.testData, { valueEncoding: 'binary' }, function (err, value) {
             refute(err)
             assert(value instanceof Buffer, 'value is buffer')
             assert.equals(value.toString(), 'binarydata')
@@ -107,11 +107,11 @@ buster.testCase('Binary API', {
       }.bind(this))
     }
 
-  , 'test put() and get() with binary key & value {encoding:binary}': function (done) {
+  , 'test put() and get() with binary key & value {valueEncoding:binary}': function (done) {
       this.openTestDatabase(function (db) {
-        db.put(this.testData, this.testData, { encoding: 'binary' }, function (err) {
+        db.put(this.testData, this.testData, { valueEncoding: 'binary' }, function (err) {
           refute(err)
-          db.get(this.testData, { encoding: 'binary' }, function (err, value) {
+          db.get(this.testData, { valueEncoding: 'binary' }, function (err, value) {
             refute(err)
             common.checkBinaryTestData(value, done)
           }.bind(this))
@@ -120,13 +120,13 @@ buster.testCase('Binary API', {
     }
 
 
-  , 'test put() and del() and get() with binary key {encoding:binary}': function (done) {
+  , 'test put() and del() and get() with binary key {valueEncoding:binary}': function (done) {
       this.openTestDatabase(function (db) {
-        db.put(this.testData, 'binarydata', { encoding: 'binary' }, function (err) {
+        db.put(this.testData, 'binarydata', { valueEncoding: 'binary' }, function (err) {
           refute(err)
-          db.del(this.testData, { encoding: 'binary' }, function (err) {
+          db.del(this.testData, { valueEncoding: 'binary' }, function (err) {
             refute(err)
-            db.get(this.testData, { encoding: 'binary' }, function (err, value) {
+            db.get(this.testData, { valueEncoding: 'binary' }, function (err, value) {
               assert(err)
               refute(value)
               done()
@@ -150,7 +150,7 @@ buster.testCase('Binary API', {
               async.forEach(
                   ['foo', 'bar', 'baz']
                 , function (key, callback) {
-                    db.get(key, { encoding: 'binary' }, function (err, value) {
+                    db.get(key, { valueEncoding: 'binary' }, function (err, value) {
                       refute(err)
                       if (key == 'baz') {
                         assert(value instanceof Buffer, 'value is buffer')

--- a/test/deferred-open-test.js
+++ b/test/deferred-open-test.js
@@ -18,7 +18,7 @@ buster.testCase('Deferred open()', {
   , 'put() and get() on pre-opened database': function (done) {
       var location = common.nextLocation()
       // 1) open database without callback, opens in worker thread
-        , db       = levelup(location, { createIfMissing: true, errorIfExists: true, encoding: 'utf8' })
+        , db       = levelup(location, { createIfMissing: true, errorIfExists: true, valueEncoding: 'utf8' })
 
       this.closeableDatabases.push(db)
       this.cleanupDirs.push(location)
@@ -61,7 +61,7 @@ buster.testCase('Deferred open()', {
   , 'batch() on pre-opened database': function (done) {
       var location = common.nextLocation()
       // 1) open database without callback, opens in worker thread
-        , db       = levelup(location, { createIfMissing: true, errorIfExists: true, encoding: 'utf8' })
+        , db       = levelup(location, { createIfMissing: true, errorIfExists: true, valueEncoding: 'utf8' })
 
       this.closeableDatabases.push(db)
       this.cleanupDirs.push(location)
@@ -104,7 +104,7 @@ buster.testCase('Deferred open()', {
   , 'chained batch() on pre-opened database': function (done) {
       var location = common.nextLocation()
       // 1) open database without callback, opens in worker thread
-        , db       = levelup(location, { createIfMissing: true, errorIfExists: true, encoding: 'utf8' })
+        , db       = levelup(location, { createIfMissing: true, errorIfExists: true, valueEncoding: 'utf8' })
 
       this.closeableDatabases.push(db)
       this.cleanupDirs.push(location)
@@ -169,7 +169,7 @@ buster.testCase('Deferred open()', {
   , 'maxListeners warning': function (done) {
       var location   = common.nextLocation()
       // 1) open database without callback, opens in worker thread
-        , db         = levelup(location, { createIfMissing: true, errorIfExists: true, encoding: 'utf8' })
+        , db         = levelup(location, { createIfMissing: true, errorIfExists: true, valueEncoding: 'utf8' })
         , stderrMock = this.mock(console)
 
       this.closeableDatabases.push(db)

--- a/test/encoding-test.js
+++ b/test/encoding-test.js
@@ -16,7 +16,7 @@ buster.testCase('Encoding', {
 
   , 'test safe decode in get()': function (done) {
       this.openTestDatabase(
-          { createIfMissing: true, errorIfExists: true, encoding: 'utf8' }
+          { createIfMissing: true, errorIfExists: true, valueEncoding: 'utf8' }
         , function (db) {
             db.put('foo', 'this {} is [] not : json', function (err) {
               refute(err)
@@ -37,7 +37,7 @@ buster.testCase('Encoding', {
 
   , 'test safe decode in readStream()': function (done) {
       this.openTestDatabase(
-          { createIfMissing: true, errorIfExists: true, encoding: 'utf8' }
+          { createIfMissing: true, errorIfExists: true, valueEncoding: 'utf8' }
         , function (db) {
             db.put('foo', 'this {} is [] not : json', function (err) {
               refute(err)
@@ -67,7 +67,7 @@ buster.testCase('Encoding', {
       // write a value as JSON, read as utf8 and check
       // the fact that we can get with keyEncoding of utf8 should demonstrate that
       // the key is not encoded as JSON
-      this.openTestDatabase({ encoding: 'json' }, function (db) {
+      this.openTestDatabase({ valueEncoding: 'json' }, function (db) {
         db.put('foo:foo', { bar: 'bar' }, function (err) {
           refute(err)
           db.get('foo:foo', { keyEncoding: 'utf8', valueEncoding: 'utf8' }, function (err, value) {
@@ -79,7 +79,7 @@ buster.testCase('Encoding', {
       })
     }
   , 'test batch op encoding': function (done) {
-      this.openTestDatabase({ encoding: 'json' }, function (db) {
+      this.openTestDatabase({ valueEncoding: 'json' }, function (db) {
         db.batch([
             {
               type : 'put',

--- a/test/init-test.js
+++ b/test/init-test.js
@@ -58,7 +58,7 @@ buster.testCase('Init & open()', {
       var location = common.nextLocation()
       levelup(
           location
-        , { createIfMissing: true, errorIfExists: true, encoding: 'binary' }
+        , { createIfMissing: true, errorIfExists: true, valueEncoding: 'binary' }
         , function (err, db) {
             refute(err)
 

--- a/test/inject-encoding-test.js
+++ b/test/inject-encoding-test.js
@@ -22,7 +22,7 @@ buster.testCase('JSON API', {
           levelup(location, {
             createIfMissing: true,
             errorIfExists: true,
-            encoding: {
+            valueEncoding: {
               encode: msgpack.encode,
               decode: msgpack.decode,
               buffer: true,

--- a/test/json-test.js
+++ b/test/json-test.js
@@ -17,7 +17,7 @@ buster.testCase('JSON API', {
         this.runTest = function (testData, assertType, done) {
           var location = common.nextLocation()
           this.cleanupDirs.push(location)
-          levelup(location, { createIfMissing: true, errorIfExists: true, encoding: {encode: JSON.stringify, decode: JSON.parse }}, function (err, db) {
+          levelup(location, { createIfMissing: true, errorIfExists: true, valueEncoding: {encode: JSON.stringify, decode: JSON.parse }}, function (err, db) {
             refute(err)
             if (err) return
 

--- a/test/open-patchsafe-test.js
+++ b/test/open-patchsafe-test.js
@@ -14,7 +14,7 @@ function test(fun) {
   return function (done) {
     var location = common.nextLocation()
     // 1) open database without callback, opens in worker thread
-      , db       = levelup(location, { createIfMissing: true, errorIfExists: true, encoding: 'utf8'})
+      , db       = levelup(location, { createIfMissing: true, errorIfExists: true, valueEncoding: 'utf8'})
 
     this.closeableDatabases.push(db)
     this.cleanupDirs.push(location)

--- a/test/read-stream-test.js
+++ b/test/read-stream-test.js
@@ -558,7 +558,7 @@ buster.testCase('ReadStream', {
               refute(err)
               db.close(function (err) {
                 refute(err)
-                var db2 = levelup(db.location, { createIfMissing: false, errorIfExists: false, encoding: 'utf8' })
+                var db2 = levelup(db.location, { createIfMissing: false, errorIfExists: false, valueEncoding: 'utf8' })
                 execute(db2)
               })
             }.bind(this))


### PR DESCRIPTION
We undocumented it a while I go, now it's time to finally kick it out for `1.0.0`.