### PR TITLE
remove reference to write-stream and iterators

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Introduction
 
 **[LevelDB](https://github.com/google/leveldb)** is a simple key/value data store built by Google, inspired by BigTable. It's used in Google Chrome and many other products. LevelDB supports arbitrary byte arrays as both keys and values, singular *get*, *put* and *delete* operations, *batched put and delete*, bi-directional iterators and simple compression using the very fast [Snappy](http://code.google.com/p/snappy/) algorithm.
 
-**LevelUP** aims to expose the features of LevelDB in a **Node.js-friendly way**. All standard `Buffer` encoding types are supported, as is a special JSON encoding. LevelDB's iterators are exposed as a Node.js-style **readable stream** a matching **writeable stream** converts writes to *batch* operations.
+**LevelUP** aims to expose the features of LevelDB in a **Node.js-friendly way**. All standard `Buffer` encoding types are supported, as is a special JSON encoding. LevelDB's iterators are exposed as a Node.js-style **readable stream**.
 
 LevelDB stores entries **sorted lexicographically by keys**. This makes LevelUP's <a href="#createReadStream"><code>ReadStream</code></a> interface a very powerful query mechanism.
 


### PR DESCRIPTION
I'm also wondering if we should try to reformulate a bit. Since I'm not a native english speaker I might be off. In the beginning we mention `bi-directional iterators` as one of the features and we say this in plural, i.e. there are at least two types of iterators.

But since `write-stream` has been removed, does this mean we have one type of iterator, or are there still several types of iterators? Or is it a single bi-directional iterator that is exposed by `createReadStream()`? If there are different types of iterators I think we should be more specific in what they are to get rid of ambiguity.