### PR TITLE
node 0.12 and iojs on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
   - "0.10"
+  - "0.12"
+  - "iojs"
 branches:
   only:
     - master


### PR DESCRIPTION
This replaces 0.10 with 0.12 and iojs. Should we keep 0.10 or carry on?

/cc @jcrugzz @juliangruber @mcollina @rvagg 