### PR TITLE
refactor iterators using new deferred-leveldown

### DIFF
--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -140,7 +140,7 @@ LevelUP.prototype.close = function (callback) {
         callback.apply(null, arguments)
     })
     this.emit('closing')
-    this.db = null
+    this.db = new DeferredLevelDOWN(this.location)
   } else if (this._status == 'closed' && callback) {
     return process.nextTick(callback)
   } else if (this._status == 'closing' && callback) {
@@ -386,17 +386,7 @@ LevelUP.prototype.createReadStream = function (options) {
       }
     : function () {}
 
-  var stream = new ReadStream(options, makeData)
-
-  if (this.isOpen()) {
-    stream.setIterator(self.db.iterator(options))
-  } else {
-    this.once('ready', function () {
-      stream.setIterator(self.db.iterator(options))
-    })
-  }
-
-  return stream
+  return new ReadStream(this.db.iterator(options), options, makeData)
 }
 
 LevelUP.prototype.keyStream =

--- a/lib/read-stream.js
+++ b/lib/read-stream.js
@@ -13,38 +13,25 @@ var Readable      = require('readable-stream').Readable
 
 
 
-function ReadStream (options, makeData) {
+function ReadStream (iterator, options, makeData) {
   if (!(this instanceof ReadStream))
-    return new ReadStream(options, makeData)
+    return new ReadStream(iterator, options, makeData)
 
   Readable.call(this, { objectMode: true, highWaterMark: options.highWaterMark })
 
   // purely to keep `db` around until we're done so it's not GCed if the user doesn't keep a ref
 
-  this._waiting = false
+  this._iterator = iterator
   this._options = options
   this._makeData = makeData
 }
 
 inherits(ReadStream, Readable)
 
-ReadStream.prototype.setIterator = function (it) {
-  var self = this
-  this._iterator = it
-  if(this._destroyed) return it.end(function () {})
-  if(this._waiting) {
-    this._waiting = false
-    return this._read()
-  }
-  return this
-}
-
 ReadStream.prototype._read = function read () {
   var self = this
   if (self._destroyed)
     return
-  if(!self._iterator)
-    return this._waiting = true
 
   self._iterator.next(function(err, key, value) {
     if (err || (key === undefined && value === undefined)) {
@@ -74,14 +61,10 @@ ReadStream.prototype._cleanup = function (err) {
   if (err)
     self.emit('error', err)
 
-  if (self._iterator) {
-    self._iterator.end(function () {
-      self._iterator = null
-      self.emit('close')
-    })
-  } else {
+  self._iterator.end(function () {
+    self._iterator = null
     self.emit('close')
-  }
+  })
 }
 
 ReadStream.prototype.destroy = function () {

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
   ],
   "main": "lib/levelup.js",
   "dependencies": {
-    "deferred-leveldown": "~0.2.0",
-    "level-errors": "~1.0.3",
+    "deferred-leveldown": "^0.3.0",
     "level-codec": "^5.0.0",
+    "level-errors": "~1.0.3",
     "prr": "~0.0.0",
     "readable-stream": "~1.0.26",
     "semver": "~2.3.1",


### PR DESCRIPTION
this depends on https://github.com/Level/deferred-leveldown/pull/6

This removes deferred iterator logic from levelup as that's handled in the pull request above. Also the readable stream interface is one step closer to being ready to be split out into its own module.