### PR TITLE
fix stream-bench.js

### DIFF
--- a/test/benchmarks/stream-bench.js
+++ b/test/benchmarks/stream-bench.js
@@ -1,7 +1,6 @@
 const levelup = require(process.argv[2] || '../../')
     , crypto  = require('crypto')
     , srcdb   = levelup('/tmp/source.db')
-    , dstdb   = levelup('/tmp/destination.db')
 
     , batch   = 10000
     , total   = 200000
@@ -28,16 +27,33 @@ srcdb.on('ready', function () {
 
   populate(0, function () {
     var batchTime = Date.now() - start
+    console.log('Filled source! Took %sms, reading data now...', batchTime)
 
-    console.log('--------------------------------------------------------------')
-    console.log('Filled source! Took', batchTime + 'ms, streaming to destination...')
-
-    start = Date.now()
-    srcdb.createReadStream()
-      .on('end', function () {
-        var copyTime = Date.now() - start
-        console.log('Done! Took', copyTime + 'ms,', Math.round((copyTime / batchTime) * 100) + '% of batch time')
+    run(function () {
+      run(function () {
+        run()
       })
-      .pipe(dstdb.createWriteStream())
+    })
   })
 })
+
+function run (cb) {
+  stream({}, function () {
+    stream({ keys: true }, function () {
+      stream({ values: true }, function () {
+        stream({ keys: true, values: true }, cb)
+      })
+    })
+  })
+}
+
+function stream (opts, cb) {
+  var start = Date.now()
+  srcdb.createReadStream()
+    .on('end', function () {
+      var copyTime = Date.now() - start
+      console.log('Done! Took %sms with %j', copyTime, opts)
+      if (cb) cb()
+    })
+    .on('data', function(){})
+}


### PR DESCRIPTION
This needed to be touched since we removed writestreams. i also added benchmarks for different `{ keys, values }` combinations and made sure they run often enough so performance is a stable characteristic.

Current output:

```bash
 ∴  benchmarks (master) : node stream-bench.js
Filled source! Took 2702ms, reading data now...
Done! Took 1682ms with {}
Done! Took 1336ms with {"keys":true}
Done! Took 1083ms with {"values":true}
Done! Took 1222ms with {"keys":true,"values":true}
Done! Took 1112ms with {}
Done! Took 1134ms with {"keys":true}
Done! Took 1065ms with {"values":true}
Done! Took 1182ms with {"keys":true,"values":true}
Done! Took 1272ms with {}
Done! Took 1086ms with {"keys":true}
Done! Took 1106ms with {"values":true}
Done! Took 1416ms with {"keys":true,"values":true}
```

The need for stream benchmarks was raised again in https://github.com/Level/codec/pull/5#issuecomment-94213135